### PR TITLE
Moved definition of VIGEM_TARGET and VIGEM_CLIENT to Client.h

### DIFF
--- a/include/ViGEm/Client.h
+++ b/include/ViGEm/Client.h
@@ -78,12 +78,47 @@ extern "C" {
      */
 #define VIGEM_SUCCESS(_val_) (_val_ == VIGEM_ERROR_NONE)
 
+    //
+    // Represents a driver connection object.
+    //.
+    typedef struct _VIGEM_CLIENT_T
+    {
+        HANDLE hBusDevice;
+
+    } VIGEM_CLIENT;
+
      /**
       * \typedef struct _VIGEM_CLIENT_T *PVIGEM_CLIENT
       *
       * \brief   Defines an alias representing a driver connection object.
       */
     typedef struct _VIGEM_CLIENT_T *PVIGEM_CLIENT;
+
+    //
+    // Represents the (connection) state of a target device object.
+    //.
+    typedef enum _VIGEM_TARGET_STATE
+    {
+        VIGEM_TARGET_NEW,
+        VIGEM_TARGET_INITIALIZED,
+        VIGEM_TARGET_CONNECTED,
+        VIGEM_TARGET_DISCONNECTED
+    } VIGEM_TARGET_STATE, *PVIGEM_TARGET_STATE;
+
+    //
+    // Represents a virtual gamepad object.
+    //.
+    typedef struct _VIGEM_TARGET_T
+    {
+        ULONG Size;
+        ULONG SerialNo;
+        VIGEM_TARGET_STATE State;
+        USHORT VendorId;
+        USHORT ProductId;
+        VIGEM_TARGET_TYPE Type;
+        DWORD_PTR Notification;
+
+    } VIGEM_TARGET;
 
     /**
      * \typedef struct _VIGEM_TARGET_T *PVIGEM_TARGET

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -56,41 +56,6 @@ typedef BOOL(WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFi
 LONG WINAPI vigem_internal_exception_handler(struct _EXCEPTION_POINTERS* apExceptionInfo);
 
 //
-// Represents a driver connection object.
-// 
-typedef struct _VIGEM_CLIENT_T
-{
-    HANDLE hBusDevice;
-
-} VIGEM_CLIENT;
-
-//
-// Represents the (connection) state of a target device object.
-// 
-typedef enum _VIGEM_TARGET_STATE
-{
-    VIGEM_TARGET_NEW,
-    VIGEM_TARGET_INITIALIZED,
-    VIGEM_TARGET_CONNECTED,
-    VIGEM_TARGET_DISCONNECTED
-} VIGEM_TARGET_STATE, *PVIGEM_TARGET_STATE;
-
-//
-// Represents a virtual gamepad object.
-// 
-typedef struct _VIGEM_TARGET_T
-{
-    ULONG Size;
-    ULONG SerialNo;
-    VIGEM_TARGET_STATE State;
-    USHORT VendorId;
-    USHORT ProductId;
-    VIGEM_TARGET_TYPE Type;
-    DWORD_PTR Notification;
-
-} VIGEM_TARGET;
-
-//
 // Initializes a virtual gamepad object.
 // 
 PVIGEM_TARGET FORCEINLINE VIGEM_TARGET_ALLOC_INIT(


### PR DESCRIPTION
It looks like public API of ViGEmClient lacks some essential definitions, as they are misplaced in .c file.