### PR TITLE
Fixed crash on destructing NotificationRequestPool

### DIFF
--- a/src/NotificationRequestPool.cpp
+++ b/src/NotificationRequestPool.cpp
@@ -107,6 +107,13 @@ void NotificationRequestPool::operator()()
             continue;
         }
 
+        // handles are closed...?
+        if (ret == WAIT_FAILED)
+        {
+            // exits function (terminates thread)
+            break;
+        }
+
         // index of the request which just got completed
         const auto index = ret - WAIT_OBJECT_0;
         // grab associated request


### PR DESCRIPTION
My application using ViGEmClient crashes when calling `vigem_target_x360_unregister_notification()`.

When `NotificationRequestPool::~NotificationRequestPool()` calls `CloseHandle(wait_handle)`,

in `void NotificationRequestPool::operator()()`

```
        // wait for the first pending I/O to signal its event
        const auto ret = WaitForMultipleObjects(
            requests_.size(),
            wait_handles_,
            FALSE, // first one to be signaled wins
            25 // don't block indefinitely so worker can be canceled
        );
```
returns `WAIT_FAILED (0xFFFFFFFF)`.

Then

```
        // grab associated request
        const auto req = requests_[index].get();
```
with `index = 0xFFFFFFFF` causes a memory access violation.

I added some code checking whether `WaitForMultipleObjects()` returned `WAIT_FAILED`.

### Another solution
Or calling `NotificationRequestPool::terminate(); Sleep(100);` from destructor before closing the handle also fixes the problem.

### My build enviroment
- Visual Studio 2019 Preview (16.3.0 Preview 1.0)
- boost 1.70 (from NuGet *-src packages)

Thanks,
