### PR TITLE
Removed NotificationPool and boost references. Created a new notification thread handler logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@
 /app/Tester/Debug
 /Debug
 /app/Tester/x64/Debug
+/app/Tester/x64/Release/Tester.tlog
+/app/Tester/x64/Release/Tester.log
+/app/Tester/x64/Release/Tester.obj
+/app/Tester/x64/Release/vc141.pdb
+/app/Tester/x64/Release/vcpkg.applocal.log

--- a/src/Internal.h
+++ b/src/Internal.h
@@ -51,7 +51,7 @@ typedef enum _VIGEM_TARGET_STATE
     VIGEM_TARGET_DISCONNECTED
 } VIGEM_TARGET_STATE, *PVIGEM_TARGET_STATE;
 
-class NotificationRequestPool;
+
 
 //
 // Represents a virtual gamepad object.
@@ -66,6 +66,7 @@ typedef struct _VIGEM_TARGET_T
     VIGEM_TARGET_TYPE Type;
     FARPROC Notification;
 
-    std::unique_ptr<NotificationRequestPool> NotificationPool;
-
+	bool closingNotificationThreads;
+	HANDLE cancelNotificationThreadEvent;
+	std::unique_ptr<std::vector<std::thread>> notificationThreadList;
 } VIGEM_TARGET;

--- a/src/ViGEmClient.vcxproj
+++ b/src/ViGEmClient.vcxproj
@@ -306,13 +306,9 @@
     <ClInclude Include="$(SolutionDir)\include\ViGEm\Util.h" />
     <ClInclude Include="$(SolutionDir)\include\ViGEm\km\BusShared.h" />
     <ClInclude Include="Internal.h" />
-    <ClInclude Include="NotificationRequestPool.h" />
-    <ClInclude Include="XusbNotificationRequest.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="NotificationRequestPool.cpp" />
     <ClCompile Include="ViGEmClient.cpp" />
-    <ClCompile Include="XusbNotificationRequest.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/ViGEmClient.vcxproj.filters
+++ b/src/ViGEmClient.vcxproj.filters
@@ -33,24 +33,12 @@
     <ClInclude Include="$(SolutionDir)\include\ViGEm\km\BusShared.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="XusbNotificationRequest.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="NotificationRequestPool.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Internal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ViGEmClient.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="XusbNotificationRequest.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="NotificationRequestPool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
, which is simpler and more straight forward than use of BOOST:ASIO library. 

At the same time fixed a thread cleanup bug in unregister_notification functions (sometimes the old code crashed when a notifications was unregistered. There was some multithread cleanup issue).

This fork of ViGemClient was tested with ViGem.NET library in DS4Windows application. No more phantom threads left behind when a connection is closed to a controller object and no more random crashes in contr.Disconnect calls.
