### PR TITLE
Add IOCTL availability based version check utility function

### DIFF
--- a/include/ViGEm/Client.h
+++ b/include/ViGEm/Client.h
@@ -167,6 +167,20 @@ extern "C" {
     VIGEM_API void vigem_disconnect(PVIGEM_CLIENT vigem);
 
     /**
+     * A useful utility function to check if pre 1.17 driver, meant to be replaced in the future by
+     *          more robust version checks, only able to be checked after at least one device has been
+     *          successfully plugged in.
+     *
+     * @author	Jason "megadrago88" Hart
+     * @date	17.08.2021
+     *
+     * @param   target  The PVIGEM_TARGET to check against.
+     *
+     * @returns	A bool, true if the device wait ready ioctl is supported (1.17+) or false if not ( =< 1.16)
+     */
+    VIGEM_API bool vigem_target_is_waitable_add_supported(PVIGEM_TARGET target);
+
+    /**
      * Allocates an object representing an Xbox 360 Controller device.
      *
      * @author	Benjamin "Nefarius" Höglinger-Stelzer

--- a/include/ViGEm/Client.h
+++ b/include/ViGEm/Client.h
@@ -176,9 +176,9 @@ extern "C" {
      *
      * @param   target  The PVIGEM_TARGET to check against.
      *
-     * @returns	A bool, true if the device wait ready ioctl is supported (1.17+) or false if not ( =< 1.16)
+     * @returns	A BOOLEAN, true if the device wait ready ioctl is supported (1.17+) or false if not ( =< 1.16)
      */
-    VIGEM_API bool vigem_target_is_waitable_add_supported(PVIGEM_TARGET target);
+    VIGEM_API BOOLEAN vigem_target_is_waitable_add_supported(PVIGEM_TARGET target);
 
     /**
      * Allocates an object representing an Xbox 360 Controller device.

--- a/src/Internal.h
+++ b/src/Internal.h
@@ -66,6 +66,7 @@ typedef struct _VIGEM_TARGET_T
     VIGEM_TARGET_TYPE Type;
     FARPROC Notification;
     LPVOID NotificationUserData;
+    BOOL IsWaitReadyUnsupported;
 
 	HANDLE cancelNotificationThreadEvent;
 } VIGEM_TARGET;

--- a/src/Internal.h
+++ b/src/Internal.h
@@ -66,7 +66,7 @@ typedef struct _VIGEM_TARGET_T
     VIGEM_TARGET_TYPE Type;
     FARPROC Notification;
     LPVOID NotificationUserData;
-    BOOL IsWaitReadyUnsupported;
+    BOOLEAN IsWaitReadyUnsupported;
 
 	HANDLE cancelNotificationThreadEvent;
 } VIGEM_TARGET;

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -297,7 +297,7 @@ bool vigem_target_is_waitable_add_supported(PVIGEM_TARGET target)
     // Should never pass in an invalid target but doesn't hurt to check.
     //
     if (!target)
-        return false;
+        return FALSE;
 
     // TODO: Replace all this with a more robust version check system
     return !target->IsWaitReadyUnsupported;

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -290,7 +290,7 @@ void vigem_disconnect(PVIGEM_CLIENT vigem)
     }
 }
 
-bool vigem_target_is_waitable_add_supported(PVIGEM_TARGET target)
+BOOLEAN vigem_target_is_waitable_add_supported(PVIGEM_TARGET target)
 {
     //
     // Safety check to make people use the older functions and not cause issues

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -290,6 +290,19 @@ void vigem_disconnect(PVIGEM_CLIENT vigem)
     }
 }
 
+bool vigem_target_is_waitable_add_supported(PVIGEM_TARGET target)
+{
+    //
+    // Safety check to make people use the older functions and not cause issues
+    // Should never pass in an invalid target but doesn't hurt to check.
+    //
+    if (!target)
+        return false;
+
+    // TODO: Replace all this with a more robust version check system
+    return !target->IsWaitReadyUnsupported;
+}
+
 PVIGEM_TARGET vigem_target_x360_alloc(void)
 {
     const auto target = VIGEM_TARGET_ALLOC_INIT(Xbox360Wired);
@@ -439,6 +452,7 @@ VIGEM_ERROR vigem_target_add(PVIGEM_CLIENT vigem, PVIGEM_TARGET target)
 		        if (GetLastError() == ERROR_INVALID_PARAMETER)
 		        {
 			        target->State = VIGEM_TARGET_CONNECTED;
+                    target->IsWaitReadyUnsupported = true;
 
 			        error = VIGEM_ERROR_NONE;
 			        break;


### PR DESCRIPTION
Add basic utility function to be able to tell if driver is pre 1.17 via a safe client library call.