### PR TITLE
Resolve output paths relative to .vcxproj rather than .sln

### DIFF
--- a/src/ViGEmClient.vcxproj
+++ b/src/ViGEmClient.vcxproj
@@ -130,35 +130,35 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_LIB|Win32'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)lib\debug\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\lib\debug\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_DLL|Win32'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)bin\debug\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\bin\debug\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_LIB|Win32'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)lib\release\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\lib\release\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_DLL|Win32'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)bin\release\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\bin\release\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_LIB|x64'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)lib\debug\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\lib\debug\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_DLL|x64'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)bin\debug\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\bin\debug\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_LIB|x64'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)lib\release\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\lib\release\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_DLL|x64'">
     <IncludePath>$(ProjectDir)../include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <OutDir>$(SolutionDir)bin\release\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)..\bin\release\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_LIB|Win32'">
     <ClCompile>


### PR DESCRIPTION
If you build ViGEmClient on its own (through Visual Studio), you'll end up with a directory structure like this, where output files are written to top-level directories called `bin` (for DLLs) or `lib` (for static libs), e.g.:

- `ViGEmClient/ViGEmClient.sln`
- `ViGEmClient/src/ViGEmClient.vcxproj`
- `ViGEmClient/lib/release/x64/ViGEmClient.lib`

I cloned ViGEmClient into my own project as a submodule, giving me a directory structure like this:

- `myproject/build/myproject.sln`
- `myproject/build/myproject.vcxproj`
- `myproject/external/ViGEmClient/ViGEmClient.sln`
- `myproject/external/ViGEmClient/src/ViGEmClient.vcxproj`

To simplify the build process within Visual Studio, I added the project (`ViGEmClient.vcxproj`) to my solution (`myproject.sln`). However, I noticed that when I build ViGEmClient to generate static libs, they end up in an unexpected location:

- `myproject/build/myproject.sln`
- `myproject/build/myproject.vcxproj`
- `myproject/build/lib/release/x64/ViGEmClient.lib` <-- currently, output libs are written here
- `myproject/external/ViGEmClient/ViGEmClient.sln`
- `myproject/external/ViGEmClient/src/ViGEmClient.vcxproj`
- `myproject/external/ViGEmClient/lib/release/x64/ViGEmClient.lib` <-- but they should really be here

This is simply because the output directories configured in `ViGEmClient.vcxproj` are defined relative to `$(SolutionDir)`. This change updates those paths to be resolved relative to `$(ProjectDir)`, so that output files always end up in the expected locations (`ViGEmClient/lib` or `ViGEmClient/bin`) regardless of whether the library is built on its own or within another solution.

Thanks!
