### PR TITLE
Add APIs for polling USB output report data changes

### DIFF
--- a/include/ViGEm/Client.h
+++ b/include/ViGEm/Client.h
@@ -463,6 +463,36 @@ extern "C" {
      */
     VIGEM_API VIGEM_ERROR vigem_target_x360_get_user_index(PVIGEM_CLIENT vigem, PVIGEM_TARGET target, PULONG index);
 
+    /**
+     * Returns the output data of the Xbox gamepad. Output refers to the USB output report, which
+     *                is used to set LEDs and motor values.
+     *
+     * @author  Matt Wszolek
+     * @date    09.28.2021
+     *
+     * @param   vigem   The driver connection object.
+     * @param   target  The target device object.
+     * @param   output  The values that are set by the output reports
+     *
+     * @returns A VIGEM_ERROR.
+     */
+    VIGEM_API VIGEM_ERROR vigem_target_x360_get_output(PVIGEM_CLIENT vigem, PVIGEM_TARGET target, PXUSB_OUTPUT_DATA output);
+
+    /**
+     * Returns the output data of the DualShock 4 gamepad. Output refers to the USB output report,
+     *                which is used to set LED and motor values.
+     *
+     * @author  Matt Wszolek
+     * @date    09.28.2021
+     *
+     * @param   vigem   The driver connection object.
+     * @param   target  The target device object.
+     * @param   output  The values that are set by the output reports
+     *
+     * @returns A VIGEM_ERROR.
+     */
+    VIGEM_API VIGEM_ERROR vigem_target_ds4_get_output(PVIGEM_CLIENT vigem, PVIGEM_TARGET target, PDS4_OUTPUT_DATA output);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ViGEm/Common.h
+++ b/include/ViGEm/Common.h
@@ -94,9 +94,9 @@ VOID FORCEINLINE XUSB_REPORT_INIT(
 //
 typedef struct _XUSB_OUTPUT_DATA
 {
-    UCHAR LargeMotor,
-    UCHAR SmallMotor,
-    UCHAR LedNumber,
+    UCHAR LargeMotor;
+    UCHAR SmallMotor;
+    UCHAR LedNumber;
 } XUSB_OUTPUT_DATA, *PXUSB_OUTPUT_DATA;
 
 //
@@ -215,9 +215,9 @@ VOID FORCEINLINE DS4_REPORT_INIT(
 //
 typedef struct _DS4_OUTPUT_DATA
 {
-    UCHAR LargeMotor,
-    UCHAR SmallMotor,
-    DS4_LIGHTBAR_COLOR LightbarColor,
+    UCHAR LargeMotor;
+    UCHAR SmallMotor;
+    DS4_LIGHTBAR_COLOR LightbarColor;
 } DS4_OUTPUT_DATA, *PDS4_OUTPUT_DATA;
 
 #include <pshpack1.h> // pack structs tightly

--- a/include/ViGEm/Common.h
+++ b/include/ViGEm/Common.h
@@ -90,6 +90,16 @@ VOID FORCEINLINE XUSB_REPORT_INIT(
 }
 
 //
+// Values set by output reports on XINPUT_GAMEPAD
+//
+typedef struct _XUSB_OUTPUT_DATA
+{
+    UCHAR LargeMotor,
+    UCHAR SmallMotor,
+    UCHAR LedNumber,
+} XUSB_OUTPUT_DATA, *PXUSB_OUTPUT_DATA;
+
+//
 // The color value (RGB) of a DualShock 4 Lightbar
 // 
 typedef struct _DS4_LIGHTBAR_COLOR
@@ -199,6 +209,16 @@ VOID FORCEINLINE DS4_REPORT_INIT(
 
     DS4_SET_DPAD(Report, DS4_BUTTON_DPAD_NONE);
 }
+
+//
+// Values set by output reports on DualShock 4
+//
+typedef struct _DS4_OUTPUT_DATA
+{
+    UCHAR LargeMotor,
+    UCHAR SmallMotor,
+    DS4_LIGHTBAR_COLOR LightbarColor,
+} DS4_OUTPUT_DATA, *PDS4_OUTPUT_DATA;
 
 #include <pshpack1.h> // pack structs tightly
 //

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -1074,9 +1074,9 @@ VIGEM_ERROR vigem_target_x360_get_output(
 
     CloseHandle(lOverlapped.hEvent);
 
-    (*output).LargeMotor = xrn.LargeMotor;
-    (*output).SmallMotor = xrn.SmallMotor;
-    (*output).LedNumber = xrn.LedNumber;
+    output->LargeMotor = xrn.LargeMotor;
+    output->SmallMotor = xrn.SmallMotor;
+    output->LedNumber = xrn.LedNumber;
 
     return VIGEM_ERROR_NONE;
 }
@@ -1127,9 +1127,9 @@ VIGEM_ERROR vigem_target_ds4_get_output(
 
     CloseHandle(lOverlapped.hEvent);
 
-    (*output).LargeMotor = ds4rn.Report.LargeMotor;
-    (*output).SmallMotor = ds4rn.Report.SmallMotor;
-    (*output).LightbarColor = ds4rn.Report.LightbarColor;
+    output->LargeMotor = ds4rn.Report.LargeMotor;
+    output->SmallMotor = ds4rn.Report.SmallMotor;
+    output->LightbarColor = ds4rn.Report.LightbarColor;
 
     return VIGEM_ERROR_NONE;
 }

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -1027,3 +1027,109 @@ VIGEM_ERROR vigem_target_x360_get_user_index(
 
     return VIGEM_ERROR_NONE;
 }
+
+VIGEM_ERROR vigem_target_x360_get_output(
+    PVIGEM_CLIENT vigem,
+    PVIGEM_TARGET target,
+    PXUSB_OUTPUT_DATA output
+)
+{
+    if (!vigem)
+        return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+    if (!target)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+        return VIGEM_ERROR_BUS_NOT_FOUND;
+
+    if (target->SerialNo == 0 || target->Type != Xbox360Wired)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (!output)
+        return VIGEM_ERROR_INVALID_PARAMETER;
+
+    DWORD transferred = 0;
+    OVERLAPPED lOverlapped = { 0 };
+    lOverlapped.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+    XUSB_REQUEST_NOTIFICATION xrn;
+    XUSB_REQUEST_NOTIFICATION_INIT(&xrn, target->SerialNo);
+
+    DeviceIoControl(
+        vigem->hBusDevice,
+        IOCTL_XUSB_REQUEST_NOTIFICATION,
+        &xrn,
+        xrn.Size,
+        &xrn,
+        xrn.Size,
+        &transferred,
+        &lOverlapped
+    );
+
+    if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+    {
+        return VIGEM_ERROR_INVALID_TARGET;
+    }
+
+    CloseHandle(lOverlapped.hEvent);
+
+    (*output).LargeMotor = xrn.LargeMotor;
+    (*output).SmallMotor = xrn.SmallMotor;
+    (*output).LedNumber = xrn.LedNumber;
+
+    return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_ds4_get_output(
+    PVIGEM_CLIENT vigem,
+    PVIGEM_TARGET target,
+    PDS4_OUTPUT_DATA output
+)
+{
+    if (!vigem)
+        return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+    if (!target)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+        return VIGEM_ERROR_BUS_NOT_FOUND;
+
+    if (target->SerialNo == 0 || target->Type != DualShock4Wired)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (!output)
+        return VIGEM_ERROR_INVALID_PARAMETER;
+
+    DWORD transferred = 0;
+    OVERLAPPED lOverlapped = { 0 };
+    lOverlapped.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+    DS4_REQUEST_NOTIFICATION ds4rn;
+    DS4_REQUEST_NOTIFICATION_INIT(&ds4rn, _Target->SerialNo);
+
+    DeviceIoControl(
+        vigem->hBusDevice,
+        IOCTL_DS4_REQUEST_NOTIFICATION,
+        &ds4rn,
+        ds4rn.Size,
+        &ds4rn,
+        ds4rn.Size,
+        &transferred,
+        &lOverlapped
+    );
+
+    if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+    {
+        return VIGEM_ERROR_INVALID_TARGET;
+    }
+
+    CloseHandle(lOverlapped.hEvent);
+
+    (*output).LargeMotor = ds4rn.Report.LargeMotor;
+    (*output).SmallMotor = ds4rn.Report.SmallMotor;
+    (*output).LightbarColor = ds4rn.Report.LightbarColor;
+
+    return VIGEM_ERROR_NONE;
+}

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -1107,7 +1107,7 @@ VIGEM_ERROR vigem_target_ds4_get_output(
     lOverlapped.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
 
     DS4_REQUEST_NOTIFICATION ds4rn;
-    DS4_REQUEST_NOTIFICATION_INIT(&ds4rn, _Target->SerialNo);
+    DS4_REQUEST_NOTIFICATION_INIT(&ds4rn, target->SerialNo);
 
     DeviceIoControl(
         vigem->hBusDevice,


### PR DESCRIPTION
I have an issue in python where callbacks cause problems from the SDK DLL, because they are in another thread and with GIL getting the output report data is impossible.

With this solution I can create a python thread that reads the reports manually and will not cause any issues with GIL.