### PR TITLE
Fix deadlock in DS4 output report thread, debug logging not allocating memory for string; other misc. things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # This .gitignore file was automatically created by Microsoft(R) Visual Studio.
 ################################################################################
 
+.vscode/
 /.vs/ViGEmBus/v15
 /build/bin/Release
 /build/obj/Release

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -210,6 +210,7 @@ static DWORD WINAPI vigem_internal_ds4_output_report_pickup_handler(LPVOID Param
 			}
 
 			DBGPRINT(L"Win32 error from overlapped result: 0x%X", error);
+			continue;
 		}
 
 #if defined(VIGEM_VERBOSE_LOGGING_ENABLED)

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -191,7 +191,7 @@ static DWORD WINAPI vigem_internal_ds4_output_report_pickup_handler(LPVOID Param
 			DBGPRINT(L"Unexpected result from multi-object wait: 0x%X", waitResult);
 		}
 
-		if (GetOverlappedResult(pClient->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+		if (GetOverlappedResult(pClient->hBusDevice, &lOverlapped, &transferred, TRUE) == FALSE)
 		{
 			const DWORD error = GetLastError();
 			

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -114,7 +114,7 @@ static void to_hex(unsigned char* in, size_t insz, char* out, size_t outsz)
 		pout[0] = hex[(*pin >> 4) & 0xF];
 		pout[1] = hex[*pin & 0xF];
 		pout[2] = ':';
-		if (pout + 3 - out > outsz)
+		if ((size_t)(pout + 3 - out) > outsz)
 		{
 			/* Better to truncate output string than overflow buffer */
 			/* it would be still better to either return a status */

--- a/src/ViGEmClient.cpp
+++ b/src/ViGEmClient.cpp
@@ -217,8 +217,12 @@ static DWORD WINAPI vigem_internal_ds4_output_report_pickup_handler(LPVOID Param
 		DBGPRINT(L"Dumping buffer for %d", await.SerialNo);
 
 		const PCHAR dumpBuffer = (PCHAR)calloc(sizeof(DS4_OUTPUT_BUFFER), 3);
-		to_hex(await.Report.Buffer, sizeof(DS4_OUTPUT_BUFFER), dumpBuffer, sizeof(DS4_OUTPUT_BUFFER) * 3);
-		OutputDebugStringA(dumpBuffer);
+		if (dumpBuffer != nullptr)
+		{
+			to_hex(await.Report.Buffer, sizeof(DS4_OUTPUT_BUFFER), dumpBuffer, sizeof(DS4_OUTPUT_BUFFER) * 3);
+			OutputDebugStringA(dumpBuffer);
+			free(dumpBuffer);
+		}
 #endif
 
 		const PVIGEM_TARGET pTarget = pClient->pTargetsList[await.SerialNo];


### PR DESCRIPTION
DS4 output thread:
- Use `WaitForMultipleObjects` to check the status of both the thread abort and overlapped events, prevents deadlocking when disposing client
- Use `FALSE` instead of 0 when checking `GetOverlappedResult` return
- Check for `ERROR_OPERATION_ABORTED` from `GetOverlappedResult` to indicate IO cancellation
- Don't cache output report when receiving an error from `GetOverlappedResult`
- Check for nullptr when allocating packet output string

_DBGPRINT:
- Properly allocate memory
  - Switched from the intended `_malloca` to standard `malloc` because the structured exception handling for it is not great lol
- Switch magic `+ 2` to `+ sizeof(WCHAR)`
- Ensure string is null-terminated
- Output a line break

Other:
- Add `.vscode/` folder to .gitignore
- Address warning in `to_hex` about signed/unsigned mismatch in comparison