### PR TITLE
Enforce static library if no option is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@ if(ViGEmClient_DLL)
 	target_link_libraries (ViGEmClient setupAPI.lib)
 else()
 	# Generate a static library, no link dependencies needed
-	add_library(ViGEmClient EXCLUDE_FROM_ALL ${SOURCES})
+	add_library(ViGEmClient STATIC EXCLUDE_FROM_ALL ${SOURCES})
 endif()
 target_include_directories(ViGEmClient PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
If STATIC is not specified, cmake will determine whether it should be static or dynamic, which makes the option unpredictable.

Sorry for the spam, I misunderstood the reason why ViGEmClient showed up as dynamic library. It seems CMAKE makes decisions without consultation... This should work just right, and creates an option for someone who wishes to use it as a DLL. (I fully tested it this time I promise).