### PR TITLE
CMake: Setup for find_package and pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,121 @@
-Project(ViGEmClient)
 cmake_minimum_required(VERSION 3.20.2)
+project(ViGEmClient VERSION 1.21.222.0)
 
-# use -DViGEmClient_DLL=ON on the cmake command line to change this value
+# Install directory setup
+include(GNUInstallDirs)
+set(VIGEM_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+
 option(ViGEmClient_DLL "Generate a dynamic library instead of a static library" OFF)
 
-set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ViGEmClient.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/Internal.h ${CMAKE_CURRENT_SOURCE_DIR}/src/resource.h ${CMAKE_CURRENT_SOURCE_DIR}/src/ViGEmClient.rc)
-if(ViGEmClient_DLL)
-	# Generate a dynamic library with proper link dependencies
-	add_library(ViGEmClient SHARED EXCLUDE_FROM_ALL ${SOURCES})
-	target_link_libraries (ViGEmClient setupAPI.lib)
-else()
-	# Generate a static library, no link dependencies needed
-	add_library(ViGEmClient STATIC EXCLUDE_FROM_ALL ${SOURCES})
+set(VIGEM_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ViGEm/km/BusShared.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ViGEm/Client.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ViGEm/Common.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ViGEm/Util.h
+)
+set(VIGEM_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Internal.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/resource.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ViGEmClient.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ViGEmClient.rc
+)
+
+function(setup_include_directories target_name)
+    target_include_directories(
+        ${target_name}
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${VIGEM_INC_DIR}>
+    )
+endfunction()
+
+add_library(ViGEmClient STATIC
+    ${VIGEM_HEADERS}
+    ${VIGEM_SOURCES}
+)
+setup_include_directories(ViGEmClient)
+add_library(ViGEmClient::ViGEmClient ALIAS ViGEmClient)
+
+# Setup dynamic library if requested and set output name to ViGEmClient.dll
+if (ViGEmClient_DLL)
+    add_library(ViGEmClientShared SHARED
+        ${VIGEM_HEADERS}
+        ${VIGEM_SOURCES}
+    )
+    set_target_properties(ViGEmClientShared PROPERTIES
+        OUTPUT_NAME ViGEmClient
+        SUFFIX .dll
+    )
+    target_link_libraries(ViGEmClientShared PRIVATE setupapi.lib)
+    setup_include_directories(ViGEmClientShared)
+    add_library(ViGEmClient::ViGEmClientShared ALIAS ViGEmClientShared)
 endif()
-target_include_directories(ViGEmClient PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+# Setup install targets
+include(CMakePackageConfigHelpers)
+set(VIGEM_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/ViGEmClient)
+set(version_config "${PROJECT_BINARY_DIR}/ViGEmClientConfigVersion.cmake")
+set(project_config "${PROJECT_BINARY_DIR}/ViGEmClientConfig.cmake")
+set(pkgconfig ${PROJECT_BINARY_DIR}/ViGEmClient.pc)
+set(targets_export_name ViGEmClientTargets)
+set(VIGEMCLIENT_LIB_NAME ViGEmClient)
+
+write_basic_package_version_file(
+    ${version_config}
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+set(VIGEM_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
+set(VIGEM_PKGCONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+# Create path
+string(CONCAT libdir_for_pc_file "\${exec_prefix}" "/" "${VIGEM_LIB_DIR}")
+string(CONCAT includedir_for_pc_file "\${prefix}" "/" "${VIGEM_INC_DIR}")
+
+# pkg-config support
+configure_file(
+    ${PROJECT_SOURCE_DIR}/cmake/ViGEmClient.pc.in  # Input file
+    ${pkgconfig}
+    @ONLY
+)
+
+# CMake package config
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ViGEmClientConfig.cmake.in
+    ${project_config}
+    INSTALL_DESTINATION ${VIGEM_CMAKE_DIR}
+)
+
+# Setup install targets
+set(INSTALL_TARGETS ViGEmClient)
+if (ViGEmClient_DLL)
+    list(APPEND INSTALL_TARGETS ViGEmClientShared)
+endif()
+
+# Install library and headers
+install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
+        LIBRARY DESTINATION ${VIGEM_LIB_DIR}
+        ARCHIVE DESTINATION ${VIGEM_LIB_DIR}
+        PUBLIC_HEADER DESTINATION "${VIGEM_INC_DIR}/ViGEm"
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(FILES ${VIGEM_HEADERS} DESTINATION "${VIGEM_INC_DIR}/ViGEm")
+
+export(TARGETS ${INSTALL_TARGETS} NAMESPACE ViGEmClient::
+       FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
+
+# Install version, config and target files.
+install(
+    FILES ${project_config} ${version_config}
+    DESTINATION ${VIGEM_CMAKE_DIR}
+)
+install(EXPORT ${targets_export_name} DESTINATION ${VIGEM_CMAKE_DIR}
+        NAMESPACE ViGEmClient::)
+
+# TODO: pkg-config doesn't work as expected on Windows
+install(FILES "${pkgconfig}" DESTINATION "${VIGEM_PKGCONFIG_DIR}")
+

--- a/cmake/ViGEmClient.pc.in
+++ b/cmake/ViGEmClient.pc.in
@@ -1,0 +1,11 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="@CMAKE_INSTALL_PREFIX@"
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
+
+Name: ViGEmClient
+Description: ViGEmClient emulates Xbox 360 Controller and DS4 Controller for Windows using ViGEmBus.
+Version: @VIGEMCLIENT_VERSION@
+Libs: -L${libdir} -l@VIGEMCLIENT_LIB_NAME@
+Cflags: -I${includedir}
+

--- a/cmake/ViGEmClientConfig.cmake.in
+++ b/cmake/ViGEmClientConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+if (NOT TARGET ViGEmClient::ViGEmClient)
+    include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+endif()
+
+check_required_components(ViGEmClient)


### PR DESCRIPTION
Configure CMake to generate the required config files for `fing_package` to work.

Usage:

```cmake
find_package(ViGEmClient REQUIRED)

# Static linking
target_link_libraries(main PRIVATE ViGEmClient::ViGEmClient)

# Dynamic linking
target_link_libraries(main PRIVATE ViGEmClient::ViGEmClientShared)
```

pkg-config generation doesn't work as expected when installing it with `--prefix` flag. The `$prefix` and `$exec_prefix` of the generated pc file still contain the default value. This will be fine if installed normally.

To compile and generate the required file for CMake use

```sh
cmake -S . -Bbuild
```

You can later use the command below to build a release version or use `cmake --open build` to open it in Visual Studio to build. The command below just uses MSBuild in the background and `--config Debug` flag can be passed to generate a debug build.

```sh
cmake --build build --config Release
```

For installation you can use

```sh
cmake --install build
```

Not that this requires admin privileges because it tries to install it at `C:\Program (x86)\ViGEmClient` directory. This can be overridden with `--prefix` flags to specify other locations.

To make `find_package` works you need to have the path to where `ViGEmClientConfig.cmake` file is generated in an environment variable list called `CMAKE_PREFIX_PATH`, this tells `cmake` where to find the library. If the library is installed at the default location then it should be located at `C:\Program Files (x86)\ViGEmClient\lib\cmake\ViGEmClient`. Just append this path to the environment variable and it should work.

As I'm still new to `cmake` the location might not be 100% correct but it serves as a start :)